### PR TITLE
Add allPageHeaders to gatsby-config

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -30,5 +30,13 @@ module.exports = {
         icon: `src/images/gatsby-icon.png`, // This path is relative to the root of the site.
       },
     },
+    {
+      resolve: `gatsby-plugin-gatsby-cloud`,
+      options: {
+        allPageHeaders: [
+          "Strict-Transport-Security: max-age=31536000; includeSubDomains; preload",
+        ]
+      }
+    }
   ],
 }


### PR DESCRIPTION
Test for client - adding `allPagesHeaders` to `gatsby-config.js` 